### PR TITLE
Add landing page with video background

### DIFF
--- a/frontend/app/clientWrapper.tsx
+++ b/frontend/app/clientWrapper.tsx
@@ -12,20 +12,24 @@ export default function ClientWrapper({ children }: { children: React.ReactNode 
   // Check if the user is authenticated
   const token = useAppSelector((state) => state.auth.token);
   
-  // Check if the current page is the login page
-  const isLoginPage = pathname === "/login";
+  // Public pages that don't require authentication
+  const isPublicPage = pathname === "/" || pathname === "/login";
 
   useEffect(() => {
-    // If the user is not authenticated and is not on the login page, redirect to login
-    if (!token && !isLoginPage) {
+    // If the user is not authenticated and is not on a public page, redirect to login
+    if (!token && !isPublicPage) {
       router.push("/login");
     }
-  }, [token, isLoginPage, router]);
+  }, [token, isPublicPage, router]);
 
   return (
     <>
       {/* Only use DashboardWrapper for authenticated pages */}
-      {isLoginPage ? children : <DashboardWrapper>{children}</DashboardWrapper>}
+      {isPublicPage ? (
+        children
+      ) : (
+        <DashboardWrapper>{children}</DashboardWrapper>
+      )}
     </>
   );
 }

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,9 +1,25 @@
-"use client"
+"use client";
+import HomeNavbar from "../components/HomeNavbar";
 
 const Homepage = () => {
   return (
-    <div className=''>Homepage</div>
-  )
-}
+    <div className="relative flex items-center justify-center min-h-screen overflow-hidden text-white">
+      <video
+        className="absolute top-0 left-0 w-full h-full object-cover"
+        autoPlay
+        loop
+        muted
+        playsInline
+        src="/background.mp4"
+      />
+      <div className="absolute inset-0 bg-black/50" />
+      <HomeNavbar />
+      <div className="relative z-10 text-center px-4">
+        <h1 className="text-4xl md:text-6xl font-bold">VIP Concierge</h1>
+        <p className="text-xl md:text-2xl mt-4">Seamless Airport Experiences</p>
+      </div>
+    </div>
+  );
+};
 
-export default Homepage
+export default Homepage;

--- a/frontend/components/HomeNavbar.tsx
+++ b/frontend/components/HomeNavbar.tsx
@@ -1,0 +1,14 @@
+"use client";
+import Link from "next/link";
+
+const HomeNavbar = () => {
+  return (
+    <nav className="absolute top-0 left-0 p-4 z-10">
+      <Link href="/login" className="text-white hover:underline">
+        Login
+      </Link>
+    </nav>
+  );
+};
+
+export default HomeNavbar;


### PR DESCRIPTION
## Summary
- add a minimal HomeNavbar component
- implement a fullscreen video landing page with overlayed text
- allow home page access without login redirect
- add placeholder background video file

## Testing
- `npm run type-check` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_6846b2f2af64832883166b7f570b6080